### PR TITLE
Fix mouse position in Firefox 33

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -343,14 +343,8 @@ function launchParticlesJS(tag_id, params){
 
     /* el on mousemove */
     detect_el.onmousemove = function(e){
-      if(detect_el == window){
-        var pos_x = e.clientX,
-            pos_y = e.clientY;
-      }
-      else{
-        var pos_x = e.offsetX,
-            pos_y = e.offsetY;
-      }
+      var pos_x = e.clientX || e.offsetX,
+          pos_y = e.clientY || e.offsetY;
 
       if(pJS){
 


### PR DESCRIPTION
Using Firefox 33 under Ubuntu 14.04 I couldn't get the script to detect my mouse position or "push" new particles in the animation when `interactivity.detect_on = "canvas"` (`"window"` is fine).
It seemed the fix from 88d5f02231bcc2e12f52d6d5755554058c3456cf broke it and ff preferes `e.clientX` and `e.clientY`.

I just added a "or" condition to let the browser decide what's best for him. I couldn't check the result under Chrome, Safari or IE but I guess that does the job.
