### PR TITLE
proper removal of pJS to avoid mouse events' errors

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -439,7 +439,7 @@ function launchParticlesJS(tag_id, params){
   pJS.fn.vendors.destroy = function(){
     cancelAnimationFrame(pJS.fn.requestAnimFrame);
     canvas_el.remove();
-    delete pJS;
+    pJS = null;
   };
 
 


### PR DESCRIPTION
Destroying the canvas and deleting pJS variable results in the error on mouse events. To do this properly It should remove mouse listeners on destroy call.