### PR TITLE
Add array selection for color_random

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -263,13 +263,17 @@ function launchParticlesJS(tag_id, params){
     if (pJS.retina) this.radius *= pJS.canvas.pxratio;
 
     /* color */
-    if(pJS.particles.color_random){
+    if(pJS.particles.color_random === true){
       this.color = {
         r: (Math.floor(Math.random() * (255 - 0 + 1)) + 0),
         g: (Math.floor(Math.random() * (255 - 0 + 1)) + 0),
         b: (Math.floor(Math.random() * (255 - 0 + 1)) + 0)
       }
-    }else{
+    }
+     else if( pJS.particles.color_random instanceof Array){
+	    this.color = pJS.particles.color_random[Math.floor(Math.random() * pJS.particles.color_random.length)];
+    }
+    else{
       this.color = color;
     }
 
@@ -291,7 +295,7 @@ function launchParticlesJS(tag_id, params){
 
   pJS.fn.particle.prototype.draw = function() {
 
-    pJS.canvas.ctx.fillStyle = 'rgba('+this.color.r+','+this.color.g+','+this.color.b+','+this.opacity+')';
+    pJS.canvas.ctx.fillStyle = this.color.toString().charAt(0) === '#' ?  this.color : 'rgba('+this.color.r+','+this.color.g+','+this.color.b+','+this.opacity+')';
     pJS.canvas.ctx.beginPath();
 
     switch(pJS.particles.shape){


### PR DESCRIPTION
Added ability for Particles.js to accept an array as a value for color_random. If the value is an array it will randomly select an element from the array for the fillStyle. The values must be HEX values at the moment.

For example, if you set:

`color_random: ['#ffaa44', '#ffffaa', '#445500']`

It will randomly select one of those three values and use it to fill the particle. It can accept any number of values within the array.