### PR TITLE
Add user defined inline collision boxes.

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -83,6 +83,8 @@ function launchParticlesJS(tag_id, params){
     }
   };
 
+  window.pJS = pJS;
+
   /* params settings */
   if(params){
     if(params.particles){


### PR DESCRIPTION
This adds an option `colissionRectangles` which takes objects `{x, width, y, height}` that cause collisions the same way going out of bounds does. Because we needed to keep the dots away from the center region of the page.

![screenshot 2015-02-24 22 44 18](https://cloud.githubusercontent.com/assets/48965/6351502/18cd433a-bc77-11e4-9cfd-e89da395153a.png)
