### PR TITLE
Generate speed independent of direction

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -284,8 +284,9 @@ function launchParticlesJS(tag_id, params){
     }
 
     /* animation - velocity for speed */
-    this.vx = -.5 + Math.random();
-    this.vy = -.5 + Math.random();
+    var theta = 2.0 * Math.PI * Math.random();
+    this.vx = Math.cos(theta);
+    this.vy = Math.sin(theta);
 
   };
 


### PR DESCRIPTION
By generating the x and y components independently within the range [-1,
1], the (x, y) speed will be within a square. Particles traveling in a
more diagonal direction will tend to be faster.

This change will generate the (x, y) speed within the unit circle (still
in the [-1, 1] range for x and for y) so that the total speed is
independent of the direction.