### PR TITLE
adding onclick pause option

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ key | option type / notes | example
 `interactivity.events.onhover.enable` | boolean | `true` / `false`
 `interactivity.events.onhover.mode` | string <br /> array selection | `"grab"` <br /> `"bubble"` <br /> `"repulse"` <br /> `["grab", "bubble"]`
 `interactivity.events.onclick.enable` | boolean | `true` / `false`
-`interactivity.events.onclick.mode` | string <br /> array selection | `"push"` <br /> `"remove"` <br /> `"bubble"` <br /> `"repulse"` <br /> `["push", "repulse"]`
+`interactivity.events.onclick.mode` | string <br /> array selection | `"push"` <br /> `"remove"` <br /> `"bubble"` <br /> `"repulse"` <br /> `"pause"` <br /> `["push", "repulse"]`
 `interactivity.events.resize` | boolean | `true` / `false`
 `interactivity.events.modes.grab.distance` | number | `100`
 `interactivity.events.modes.grab.line_linked.opacity` | number (0 to 1) | `0.75`

--- a/particles.js
+++ b/particles.js
@@ -150,7 +150,8 @@ var pJS = function(tag_id, params){
     mode_grab_distance: pJS.interactivity.modes.grab.distance,
     mode_bubble_distance: pJS.interactivity.modes.bubble.distance,
     mode_bubble_size: pJS.interactivity.modes.bubble.size,
-    mode_repulse_distance: pJS.interactivity.modes.repulse.distance
+    mode_repulse_distance: pJS.interactivity.modes.repulse.distance,
+    mode_paused: false, 
   };
 
 
@@ -1149,6 +1150,18 @@ var pJS = function(tag_id, params){
                 pJS.tmp.repulse_clicking = false;
               }, pJS.interactivity.modes.repulse.duration*1000)
             break;
+            
+            case 'pause':
+                if(pJS.tmp.mode_paused){
+                    pJS.particles.move.enable = true;
+                    pJS.fn.particlesRefresh();
+                    pJS.tmp.mode_paused = false;
+                } else {
+                    pJS.particles.move.enable = false;
+                    pJS.tmp.mode_paused = true;
+                };
+            break;
+            
 
           }
 


### PR DESCRIPTION
Added the ability to pause the motion of particles by clicking on the canvas.  This may be a simple solution to this issue: https://github.com/VincentGarreau/particles.js/issues/88

I did not add it to the onhover mode as that it resets the locations of the particles.   

Also, I am not sure which minifier you use so I have not updated the .min.js file.
