### PR TITLE
fixes for destroy method

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -1235,8 +1235,8 @@ var pJS = function(tag_id, params){
 
   pJS.fn.vendors.destroypJS = function(){
     cancelAnimationFrame(pJS.fn.drawAnimFrame);
-    canvas_el.remove();
-    pJSDom = null;
+    canvas_el.parentElement.removeChild(canvas_el);
+    pJSDom = [];
   };
 
 


### PR DESCRIPTION
canvas_el.remove() -> remove method causing an error on Internet Explorer
pJSDom = null; -> This block getting an error when reinit particle-js after destroy method invoked. so that should be an empty array not null