### PR TITLE
Remove deprecated arguments.callee

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -1413,12 +1413,12 @@ var pJS = function(tag_id, params){
 
 /* ---------- global functions - vendors ------------ */
 
-Object.deepExtend = function(destination, source) {
+Object.deepExtend = function deepExtendFunction(destination, source) {
   for (var property in source) {
     if (source[property] && source[property].constructor &&
      source[property].constructor === Object) {
       destination[property] = destination[property] || {};
-      arguments.callee(destination[property], source[property]);
+      deepExtendFunction(destination[property], source[property]);
     } else {
       destination[property] = source[property];
     }


### PR DESCRIPTION
This removes this deprecated feature to make this codebase future proof!

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee

Fixes #123