### PR TITLE
Window detect when canvas not full window

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ particlesJS.load('particles-js', 'assets/particles.json', function() {
         "distance": 800,
         "size": 80,
         "duration": 2,
-        "opacity": 8,
+        "opacity": 0.8,
         "speed": 3
       },
       "repulse": {

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ key | option type / notes | example
 `particles.number.density.enable` | boolean | `true` / `false` 
 `particles.number.density.value_area` | number | `800`
 `particles.color.value` | HEX (string) <br /> RGB (object) <br /> HSL (object) <br /> array selection (HEX) <br /> random (string) | `"#b61924"` <br /> `{r:182, g:25, b:36}` <br />  `{h:356, s:76, l:41}` <br /> `["#b61924", "#333333", "999999"]` <br /> `"random"`
-`particles.number.density.value_area` | number | `800`
 `particles.shape.type` | string <br /> array selection | `"circle"` <br /> `"edge"` <br /> `"triangle"` <br /> `"polygon"` <br /> `"star"` <br /> `"image"` <br /> `["circle", "triangle", "image"]`
 `particles.shape.stroke.width` | number | `2`
 `particles.shape.stroke.color` | HEX (string) | `"#222222"`

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ particlesJS.load('particles-js', 'assets/particles.json', function() {
 ### `Options`
 
 key | option type / notes | example
-----|---------|------|------
+----|---------|------
 `particles.number.value` | number | `40`
 `particles.number.density.enable` | boolean | `true` / `false` 
 `particles.number.density.value_area` | number | `800`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ------------------------------
 ### `Demo / Generator`
 
-<a href="http://vincentgarreau.com/particles.js/" target="_blank"><img src="https://dl.dropboxusercontent.com/u/19580440/particlesjs-assets/github-screen.jpg" alt="particles.js generator" /></a>
+<a href="http://vincentgarreau.com/particles.js/" target="_blank"><img src="http://vincentgarreau.com/particles.js/assets/img/github-screen.jpg" alt="particles.js generator" /></a>
 
 Configure, export, and share your particles.js configuration on CodePen: <br />
 http://vincentgarreau.com/particles.js/

--- a/particles.js
+++ b/particles.js
@@ -1076,8 +1076,8 @@ var pJS = function(tag_id, params){
       pJS.interactivity.el.addEventListener('mousemove', function(e){
 
         if(pJS.interactivity.el == window){
-          var pos_x = e.clientX,
-              pos_y = e.clientY;
+          var pos_x = e.clientX - canvas_el.getBoundingClientRect().left,
+              pos_y = e.clientY - canvas_el.getBoundingClientRect().top;
         }
         else{
           var pos_x = e.offsetX || e.clientX,


### PR DESCRIPTION
Allow for window mousemove detect even when the canvas/particle element is not the full window but is just e.g. a hero banner. The benefit is smoother interaction particularly when the particle effect is overlaid with other elements, which would otherwise interfere with the interaction.