### PR TITLE
Fixed SVG loading issue in Safari and Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ particlesJS.load('particles-js', 'assets/particles.json', function() {
         "distance": 800,
         "size": 80,
         "duration": 2,
-        "opacity": 8,
+        "opacity": 0.8,
         "speed": 3
       },
       "repulse": {

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ key | option type / notes | example
 `particles.number.density.enable` | boolean | `true` / `false` 
 `particles.number.density.value_area` | number | `800`
 `particles.color.value` | HEX (string) <br /> RGB (object) <br /> HSL (object) <br /> array selection (HEX) <br /> random (string) | `"#b61924"` <br /> `{r:182, g:25, b:36}` <br />  `{h:356, s:76, l:41}` <br /> `["#b61924", "#333333", "999999"]` <br /> `"random"`
-`particles.number.density.value_area` | number | `800`
 `particles.shape.type` | string <br /> array selection | `"circle"` <br /> `"edge"` <br /> `"triangle"` <br /> `"polygon"` <br /> `"star"` <br /> `"image"` <br /> `["circle", "triangle", "image"]`
 `particles.shape.stroke.width` | number | `2`
 `particles.shape.stroke.color` | HEX (string) | `"#222222"`

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ particlesJS.load('particles-js', 'assets/particles.json', function() {
 ### `Options`
 
 key | option type / notes | example
-----|---------|------|------
+----|---------|------
 `particles.number.value` | number | `40`
 `particles.number.density.enable` | boolean | `true` / `false` 
 `particles.number.density.value_area` | number | `800`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ------------------------------
 ### `Demo / Generator`
 
-<a href="http://vincentgarreau.com/particles.js/" target="_blank"><img src="https://dl.dropboxusercontent.com/u/19580440/particlesjs-assets/github-screen.jpg" alt="particles.js generator" /></a>
+<a href="http://vincentgarreau.com/particles.js/" target="_blank"><img src="http://vincentgarreau.com/particles.js/assets/img/github-screen.jpg" alt="particles.js generator" /></a>
 
 Configure, export, and share your particles.js configuration on CodePen: <br />
 http://vincentgarreau.com/particles.js/

--- a/particles.js
+++ b/particles.js
@@ -416,9 +416,9 @@ var pJS = function(tag_id, params){
     }
 
     if(p.color.rgb){
-      var color_value = 'rgba('+p.color.rgb.r+','+p.color.rgb.g+','+p.color.rgb.b+','+opacity+')';
+      var color_value = 'rgb('+p.color.rgb.r+','+p.color.rgb.g+','+p.color.rgb.b+')';
     }else{
-      var color_value = 'hsla('+p.color.hsl.h+','+p.color.hsl.s+'%,'+p.color.hsl.l+'%,'+opacity+')';
+      var color_value = 'hsl('+p.color.hsl.h+','+p.color.hsl.s+'%,'+p.color.hsl.l+'%)';
     }
 
     pJS.canvas.ctx.fillStyle = color_value;
@@ -479,7 +479,9 @@ var pJS = function(tag_id, params){
         }
 
         if(img_obj){
+          pJS.canvas.ctx.globalAlpha = opacity;
           draw();
+          pJS.canvas.ctx.globalAlpha = 1;
         }
 
       break;

--- a/particles.js
+++ b/particles.js
@@ -41,7 +41,8 @@ var pJS = function(tag_id, params){
         image: {
           src: '',
           width: 100,
-          height: 100
+          height: 100,
+          replace_color: true
         }
       },
       opacity: {
@@ -381,7 +382,8 @@ var pJS = function(tag_id, params){
       var sh = pJS.particles.shape;
       this.img = {
         src: sh.image.src,
-        ratio: sh.image.width / sh.image.height
+        ratio: sh.image.width / sh.image.height,
+        replace_color: sh.image.replace_color
       }
       if(!this.img.ratio) this.img.ratio = 1;
       if(pJS.tmp.img_type == 'svg' && pJS.tmp.source_svg != undefined){
@@ -1205,7 +1207,9 @@ var pJS = function(tag_id, params){
 
     /* set color to svg element */
     var svgXml = pJS.tmp.source_svg,
-        rgbHex = /#([0-9A-F]{3,6})/gi,
+        url;
+    if (p.img.replace_color) {
+      var rgbHex = /#([0-9A-F]{3,6})/gi,
         coloredSvgXml = svgXml.replace(rgbHex, function (m, r, g, b) {
           if(p.color.rgb){
             var color_value = 'rgba('+p.color.rgb.r+','+p.color.rgb.g+','+p.color.rgb.b+','+p.opacity+')';
@@ -1214,19 +1218,23 @@ var pJS = function(tag_id, params){
           }
           return color_value;
         });
+      url = 'data:image/svg+xml;utf8,' + coloredSvgXml;
+    } else {
+      url = 'data:image/svg+xml;utf8,' + svgXml;
+    }
 
     /* prepare to create img with colored svg */
-    var svg = new Blob([coloredSvgXml], {type: 'image/svg+xml;charset=utf-8'}),
-        DOMURL = window.URL || window.webkitURL || window,
-        url = DOMURL.createObjectURL(svg);
+    // var svg = new Blob([coloredSvgXml], {type: 'image/svg+xml;charset=utf-8'}),
+    //     DOMURL = window.URL || window.webkitURL || window,
+    //     url = DOMURL.createObjectURL(svg);
 
     /* create particle img obj */
     var img = new Image();
     img.addEventListener('load', function(){
       p.img.obj = img;
       p.img.loaded = true;
-      DOMURL.revokeObjectURL(url);
-      pJS.tmp.count_svg++;
+      // DOMURL.revokeObjectURL(url);
+      pJS.tmp.count_svg = (pJS.tmp.count_svg || 0) + 1;
     });
     img.src = url;
 


### PR DESCRIPTION
* Fixed SVG render issue in Safari and Chrome (due to blob URI not supported and pJS.tmp.count_svg not initialized)
* Added option to replace the fill color of SVG or not