### PR TITLE
Add jsDelivr CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Load particles.js and configure the particles:
 <div id="particles-js"></div>
 
 <script src="particles.js"></script>
+<-- or include it directly via CDN -->
+<script src="https://cdn.jsdelivr.net/npm/particles.js@2"></script>
 ```
 
 **app.js**


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as it is the same as downloading it but easier and faster.