### PR TITLE
Fix crash when re-instantiating particles after destroy

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -1236,7 +1236,7 @@ var pJS = function(tag_id, params){
   pJS.fn.vendors.destroypJS = function(){
     cancelAnimationFrame(pJS.fn.drawAnimFrame);
     canvas_el.remove();
-    pJSDom = null;
+    pJSDom = [];
   };
 
 


### PR DESCRIPTION
Getting a crash when I call destroy, then use the same element to create Particles again.
pJSDom should be set to empty array, instead of null, to prevent null reference on 2nd time through on line 1517 at `pJSDom.push(new pJS(tag_id, params));`