### PR TITLE
disable pointer events if clicks are disabled

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -1494,6 +1494,11 @@ window.particlesJS = function(tag_id, params){
       pJS_canvas_class = 'particles-js-canvas-el',
       exist_canvas = pJS_tag.getElementsByClassName(pJS_canvas_class);
 
+  /* disable pointer events on canvas if clicks are disabled */
+  if (!params.interactivity.events.onclick.enable) {
+    pJS_tag.style.pointerEvents = 'none';
+  }
+
   /* remove canvas if exists into the pJS target tag */
   if(exist_canvas.length){
     while(exist_canvas.length > 0){


### PR DESCRIPTION
Hey, thanks for this wonderful library.

Dunno if you're going to include this change, but I used it for one of my projects: https://www.precisefunnels.com/profitable-online-shop.

My problem was, that even though the clicks were disabled in particles json, the author name and share buttons still weren't clickable in the header (because the particles canvas was still intercepting clicks), so I solved this with css pointer-events.

Maybe this should be universal behavior.