### PR TITLE
Change path for svg 'img/' > 'svg/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ particlesJS.load('particles-js', 'assets/particles.json', function() {
         "nb_sides": 5
       },
       "image": {
-        "src": "img/github.svg",
+        "src": "svg/github.svg",
         "width": 100,
         "height": 100
       }

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -35,7 +35,7 @@ particlesJS('particles-js',
           "nb_sides": 5
         },
         "image": {
-          "src": "img/github.svg",
+          "src": "svg/github.svg",
           "width": 100,
           "height": 100
         }

--- a/demo/particles.json
+++ b/demo/particles.json
@@ -20,7 +20,7 @@
         "nb_sides": 5
       },
       "image": {
-        "src": "img/github.svg",
+        "src": "svg/github.svg",
         "width": 100,
         "height": 100
       }


### PR DESCRIPTION
In the [demo](https://vincentgarreau.com/particles.js/) under 
Particles>Shape>Image>Image.src = `img/github.svg`, this does not work

When loading another image, you get a CORS error handler message directing you to use `svg/github.svg`

After changing to this path the displaying of the image worked

In this PR I changed the path to `svg/github.svg`

another fix would be to play an image at https://vincentgarreau.com/particles.js/img/github.svg