### PR TITLE
FIX: deepExtend recursion on strict mode

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -1413,12 +1413,12 @@ var pJS = function(tag_id, params){
 
 /* ---------- global functions - vendors ------------ */
 
-Object.deepExtend = function(destination, source) {
+Object.deepExtend = function de(destination, source) {
   for (var property in source) {
     if (source[property] && source[property].constructor &&
      source[property].constructor === Object) {
       destination[property] = destination[property] || {};
-      arguments.callee(destination[property], source[property]);
+      de(destination[property], source[property]);
     } else {
       destination[property] = source[property];
     }


### PR DESCRIPTION
Strict mode does not allow usage of arguments.callee. This causes an issue with Vite and newer frameworks which compile typescript/javascript in strict mode. Using a named function solves the problem and allows particlesJS with these new frameworks.