### PR TITLE
Update particles.js

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -1490,9 +1490,13 @@ window.particlesJS = function(tag_id, params){
   }
 
   /* pJS elements */
-  var pJS_tag = document.getElementById(tag_id),
-      pJS_canvas_class = 'particles-js-canvas-el',
-      exist_canvas = pJS_tag.getElementsByClassName(pJS_canvas_class);
+ var pJS_tag = document.getElementById(tag_id);
+if (!pJS_tag) {
+  console.error('Element with id ' + tag_id + ' not found.');
+  return; // 退出函数，因为无法继续执行
+}
+
+var exist_canvas = pJS_tag.getElementsByClassName(pJS_canvas_class);;
 
   /* remove canvas if exists into the pJS target tag */
   if(exist_canvas.length){


### PR DESCRIPTION
Here, `pJS_tag` is the element obtained by `getElementById`. If `tag_id` is incorrect or there is no corresponding element on the page, `pJS_tag` will be `null`. Then, when trying to call the `getElementsByClassName` method, an error will be thrown.

To resolve this issue,  :
1. Ensure that `tag_id` is correct and that there is indeed an element with that ID on the page.
2. Check if `pJS_tag` is `null` or `undefined` before calling `getElementsByClassName`.